### PR TITLE
Scope appointments to current user, add session management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development do
   # gem "spring"
 
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
+  gem 'pry-rails'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -139,6 +140,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
@@ -166,6 +168,11 @@ GEM
     nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
@@ -304,6 +311,7 @@ DEPENDENCIES
   error_highlight (>= 0.4.0)
   importmap-rails
   jbuilder
+  pry-rails
   puma (>= 5.0)
   rack-cors
   rails (= 7.1.3.2)

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -8,6 +8,10 @@ module Api
       render json: { csrf_token: form_authenticity_token }
     end
 
+    def current_user
+      User.find_by(id: session[:user_id])
+    end
+
     private
 
     def set_csrf_cookie

--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -17,7 +17,7 @@ module Api
       else
         []
       end
-      render json: appointments
+      render json: appointments, include: [:client, :support_worker]
     end
     
     def update

--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -10,7 +10,13 @@ module Api
     end
 
     def index
-      appointments = Appointment.all
+      appointments = if current_user.client
+        Appointment.where(client_id: current_user.client.id)
+      elsif current_user.support_worker
+        Appointment.where(support_worker_id: current_user.support_worker.id)
+      else
+        []
+      end
       render json: appointments
     end
     

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -4,7 +4,8 @@ module Api
       user = User.find_by(email: params[:email])
       return render json: { error: "Invalid email or password" }, status: :unauthorized unless user
       if user.valid_password?(params[:password])
-       render json: {
+        session[:user_id] = user.id       
+        render json: {
           user: user,
           client: user.client,
           support_worker: user.support_worker

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -2,4 +2,5 @@ class Client < ApplicationRecord
   belongs_to :user
   has_many :support_workers
   has_many :appointments,through: :support_workers
-  has_many :supp
+  has_many :support_workers
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,6 +1,5 @@
 class Client < ApplicationRecord
   belongs_to :user
   has_many :support_workers
-  has_many :appointments,through: :support_workers
-  has_many :support_workers
+  has_many :appointments
 end


### PR DESCRIPTION
## Summary
- Add `current_user` helper to `ApplicationController` using `session[:user_id]`
- Set `session[:user_id]` on login in `SessionsController`
- Scope `AppointmentsController#index` to return only appointments for the logged-in client or support worker

## Test plan
- [ ] Log in and hit GET /api/appointments — should return only your appointments
- [ ] Verify unauthenticated requests return empty array

🤖 Generated with [Claude Code](https://claude.com/claude-code)