### PR TITLE
Client privacy: restrict ClientsController access by role

### DIFF
--- a/app/controllers/api/clients_controller.rb
+++ b/app/controllers/api/clients_controller.rb
@@ -1,12 +1,15 @@
 module Api
   class ClientsController < ApplicationController
     def index
-      clients = Client.all
-      render json: clients
+      return render json: { error: 'Forbidden' }, status: :forbidden unless current_user&.support_worker
+      render json: Client.all
     end
 
     def show
       client = Client.find(params[:id])
+      unless current_user&.support_worker || current_user&.client&.id == client.id
+        return render json: { error: 'Forbidden' }, status: :forbidden
+      end
       render json: client
     end
   end

--- a/spec/controllers/clients_controller_spec.rb
+++ b/spec/controllers/clients_controller_spec.rb
@@ -1,33 +1,73 @@
 require 'rails_helper'
 
 RSpec.describe "ClientsController", type: :request do
-  let(:user) { User.create!(email: 'client@test.com', password: 'password123', first_name: 'Jane', last_name: 'Doe') }
-  let(:client) { Client.create!(user: user, first_name: 'Jane', last_name: 'Doe') }
+  let(:client_user) { User.create!(email: 'c@test.com', password: 'password123', first_name: 'Jane', last_name: 'Doe') }
+  let(:client) { Client.create!(user: client_user, first_name: 'Jane', last_name: 'Doe') }
+  let(:other_user) { User.create!(email: 'other@test.com', password: 'password123', first_name: 'Alice', last_name: 'Smith') }
+  let(:other_client) { Client.create!(user: other_user, first_name: 'Alice', last_name: 'Smith') }
+  let(:sw_user) { User.create!(email: 'sw@test.com', password: 'password123', first_name: 'Bob', last_name: 'Brown') }
+  let(:support_worker) { SupportWorker.create!(user: sw_user, first_name: 'Bob', last_name: 'Brown', email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney') }
 
   describe "GET /api/clients" do
-    before { client }
-
-    it 'returns all clients' do
-      get api_clients_path
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body).count).to eq(1)
+    context 'when unauthenticated' do
+      it 'returns forbidden' do
+        get api_clients_path
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
-    it 'returns client attributes' do
-      get api_clients_path
-      json = JSON.parse(response.body)
-      expect(json.first['first_name']).to eq('Jane')
-      expect(json.first['last_name']).to eq('Doe')
+    context 'when logged in as a client' do
+      before { client; post api_login_path, params: { email: client_user.email, password: 'password123' } }
+
+      it 'returns forbidden' do
+        get api_clients_path
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when logged in as a support worker' do
+      before { client; support_worker; post api_login_path, params: { email: sw_user.email, password: 'password123' } }
+
+      it 'returns all clients' do
+        get api_clients_path
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).count).to eq(1)
+      end
     end
   end
 
   describe "GET /api/clients/:id" do
-    it 'returns the requested client' do
-      get api_client_path(client)
-      expect(response).to have_http_status(:ok)
-      json = JSON.parse(response.body)
-      expect(json['id']).to eq(client.id)
-      expect(json['first_name']).to eq('Jane')
+    context 'when unauthenticated' do
+      it 'returns forbidden' do
+        get api_client_path(client)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when logged in as a client' do
+      before { client; post api_login_path, params: { email: client_user.email, password: 'password123' } }
+
+      it 'returns their own record' do
+        get api_client_path(client)
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['id']).to eq(client.id)
+      end
+
+      it 'returns forbidden for another client' do
+        other_client
+        get api_client_path(other_client)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when logged in as a support worker' do
+      before { client; support_worker; post api_login_path, params: { email: sw_user.email, password: 'password123' } }
+
+      it 'returns any client record' do
+        get api_client_path(client)
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['id']).to eq(client.id)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- `index` returns 403 unless the requester is a support worker
- `show` returns 403 unless the requester is a support worker or is viewing their own record
- Full RSpec request spec covering all role/ownership combinations

## Test plan
- [ ] Unauthenticated request → 403 on index and show
- [ ] Client user → 403 on index, 200 on own show, 403 on another client's show
- [ ] Support worker → 200 on index and show

🤖 Generated with [Claude Code](https://claude.com/claude-code)