### PR TITLE
Add appointment reminder email notifications via background job

### DIFF
--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -4,7 +4,8 @@ module Api
       return render json: { errors: 'Must be logged in to book appointments' }, status: :unauthorized unless current_user
       return render json: { errors: 'Only clients and support workers can book appointments' }, status: :forbidden unless current_user.client || current_user.support_worker
       @appointment = Appointment.new(appointment_params)
-    if @appointment.save
+      if @appointment.save
+        schedule_reminder(@appointment)
         render json: @appointment
       else
         render json: { errors: @appointment.errors.full_messages }, status: :unprocessable_entity
@@ -25,10 +26,11 @@ module Api
     def update
       appointment = Appointment.find(params[:id])
       if appointment.update(appointment_params)
+        schedule_reminder(appointment)
         render json: appointment
       else
         render json: { errors: appointment.errors.full_messages }, status: :unprocessable_entity
-      end 
+      end
     end
 
     def destroy
@@ -38,6 +40,12 @@ module Api
     end
 
     private
+
+    def schedule_reminder(appointment)
+      reminder_time = appointment.date - 24.hours
+      return unless reminder_time > Time.current
+      AppointmentReminderJob.set(wait_until: reminder_time).perform_later(appointment.id)
+    end
 
     def appointment_params
       params.require(:appointment).permit(:date, :duration, :location, :notes, :client_id, :support_worker_id)

--- a/app/jobs/appointment_reminder_job.rb
+++ b/app/jobs/appointment_reminder_job.rb
@@ -1,0 +1,11 @@
+class AppointmentReminderJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment_id)
+    appointment = Appointment.includes(:client, :support_worker).find_by(id: appointment_id)
+    return if appointment.nil? || appointment.deleted_at.present?
+
+    AppointmentMailer.reminder_to_client(appointment).deliver_now
+    AppointmentMailer.reminder_to_support_worker(appointment).deliver_now
+  end
+end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,0 +1,13 @@
+class AppointmentMailer < ApplicationMailer
+  def reminder_to_client(appointment)
+    @appointment = appointment
+    @support_worker = appointment.support_worker
+    mail(to: appointment.client.email, subject: "Reminder: appointment tomorrow with #{@support_worker.first_name} #{@support_worker.last_name}")
+  end
+
+  def reminder_to_support_worker(appointment)
+    @appointment = appointment
+    @client = appointment.client
+    mail(to: appointment.support_worker.email, subject: "Reminder: appointment tomorrow with #{@client.first_name} #{@client.last_name}")
+  end
+end

--- a/app/views/appointment_mailer/reminder_to_client.text.erb
+++ b/app/views/appointment_mailer/reminder_to_client.text.erb
@@ -1,0 +1,14 @@
+Hi <%= @appointment.client.first_name %>,
+
+This is a reminder that you have a support appointment tomorrow.
+
+Support worker: <%= @support_worker.first_name %> <%= @support_worker.last_name %>
+Date: <%= @appointment.date.strftime('%A, %d %B %Y at %H:%M') %>
+Duration: <%= @appointment.duration %> minutes
+Location: <%= @appointment.location %>
+
+<% if @appointment.notes.present? %>
+Notes: <%= @appointment.notes %>
+<% end %>
+
+See you then!

--- a/app/views/appointment_mailer/reminder_to_support_worker.text.erb
+++ b/app/views/appointment_mailer/reminder_to_support_worker.text.erb
@@ -1,0 +1,14 @@
+Hi <%= @appointment.support_worker.first_name %>,
+
+This is a reminder that you have a support appointment tomorrow.
+
+Client: <%= @client.first_name %> <%= @client.last_name %>
+Date: <%= @appointment.date.strftime('%A, %d %B %Y at %H:%M') %>
+Duration: <%= @appointment.duration %> minutes
+Location: <%= @appointment.location %>
+
+<% if @appointment.notes.present? %>
+Notes: <%= @appointment.notes %>
+<% end %>
+
+See you then!

--- a/spec/jobs/appointment_reminder_job_spec.rb
+++ b/spec/jobs/appointment_reminder_job_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentReminderJob, type: :job do
+  let(:client_user) { User.create!(email: 'client@test.com', first_name: 'Jane', last_name: 'Doe', password: 'password123') }
+  let(:client) { Client.create!(user_id: client_user.id, first_name: 'Jane', last_name: 'Doe', email: 'client@test.com') }
+  let(:support_worker_user) { User.create!(email: 'worker@test.com', first_name: 'Bob', last_name: 'Brown', password: 'password123', role: 'support_worker') }
+  let(:support_worker) { SupportWorker.create!(user_id: support_worker_user.id, email: 'worker@test.com', first_name: 'Bob', last_name: 'Brown', phone: '0400000000', age: 30, location: 'Sydney') }
+  let(:appointment) do
+    Appointment.create!(
+      client: client,
+      support_worker: support_worker,
+      date: 2.days.from_now,
+      duration: 60,
+      location: 'Sydney CBD'
+    )
+  end
+
+  describe '#perform' do
+    context 'when the appointment exists and is not deleted' do
+      it 'sends a reminder to the client' do
+        expect { described_class.perform_now(appointment.id) }
+          .to change { ActionMailer::Base.deliveries.count }.by(2)
+      end
+
+      it 'sends an email to the client address' do
+        described_class.perform_now(appointment.id)
+        recipients = ActionMailer::Base.deliveries.map(&:to).flatten
+        expect(recipients).to include(client_user.email)
+      end
+
+      it 'sends an email to the support worker address' do
+        described_class.perform_now(appointment.id)
+        recipients = ActionMailer::Base.deliveries.map(&:to).flatten
+        expect(recipients).to include('worker@test.com')
+      end
+    end
+
+    context 'when the appointment has been soft-deleted' do
+      before { appointment.update!(deleted_at: Time.current) }
+
+      it 'does not send any emails' do
+        expect { described_class.perform_now(appointment.id) }
+          .not_to change { ActionMailer::Base.deliveries.count }
+      end
+    end
+
+    context 'when the appointment does not exist' do
+      it 'does not raise an error' do
+        expect { described_class.perform_now(99999) }.not_to raise_error
+      end
+
+      it 'does not send any emails' do
+        expect { described_class.perform_now(99999) }
+          .not_to change { ActionMailer::Base.deliveries.count }
+      end
+    end
+  end
+end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentMailer, type: :mailer do
+  let(:client_user) { User.create!(email: 'client@test.com', first_name: 'Jane', last_name: 'Doe', password: 'password123') }
+  let(:client) { Client.create!(user_id: client_user.id, first_name: 'Jane', last_name: 'Doe', email: 'client@test.com') }
+  let(:support_worker_user) { User.create!(email: 'worker@test.com', first_name: 'Bob', last_name: 'Brown', password: 'password123', role: 'support_worker') }
+  let(:support_worker) { SupportWorker.create!(user_id: support_worker_user.id, email: 'worker@test.com', first_name: 'Bob', last_name: 'Brown', phone: '0400000000', age: 30, location: 'Sydney') }
+  let(:appointment) do
+    Appointment.create!(
+      client: client,
+      support_worker: support_worker,
+      date: 2.days.from_now,
+      duration: 60,
+      location: 'Sydney CBD',
+      notes: 'Bring medication list'
+    )
+  end
+
+  describe '#reminder_to_client' do
+    let(:mail) { AppointmentMailer.reminder_to_client(appointment) }
+
+    it 'sends to the client email' do
+      expect(mail.to).to eq([client_user.email])
+    end
+
+    it 'includes the support worker name in the subject' do
+      expect(mail.subject).to include('Bob Brown')
+    end
+
+    it 'includes the support worker name in the body' do
+      expect(mail.body.encoded).to include('Bob')
+    end
+
+    it 'greets the client by first name' do
+      expect(mail.body.encoded).to include('Jane')
+    end
+
+    it 'includes location in the body' do
+      expect(mail.body.encoded).to include('Sydney CBD')
+    end
+
+    it 'includes notes when present' do
+      expect(mail.body.encoded).to include('Bring medication list')
+    end
+  end
+
+  describe '#reminder_to_support_worker' do
+    let(:mail) { AppointmentMailer.reminder_to_support_worker(appointment) }
+
+    it 'sends to the support worker email' do
+      expect(mail.to).to eq(['worker@test.com'])
+    end
+
+    it 'includes the client name in the subject' do
+      expect(mail.subject).to include('Jane Doe')
+    end
+
+    it 'includes the client name in the body' do
+      expect(mail.body.encoded).to include('Jane')
+    end
+
+    it 'greets the support worker by first name' do
+      expect(mail.body.encoded).to include('Bob')
+    end
+
+    it 'includes location in the body' do
+      expect(mail.body.encoded).to include('Sydney CBD')
+    end
+
+    it 'includes notes when present' do
+      expect(mail.body.encoded).to include('Bring medication list')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Schedules a background job 24 hours before each appointment on create/update
- `AppointmentReminderJob` sends reminder emails to both client and support worker
- `AppointmentMailer` delivers personalised plain-text emails with appointment details
- Guard in job skips delivery if appointment was cancelled (soft-deleted)

## Test plan
- [x] `spec/mailers/appointment_mailer_spec.rb` — 12 examples covering recipients, subject lines, body content for both mailer methods
- [x] `spec/jobs/appointment_reminder_job_spec.rb` — 6 examples covering happy path, soft-deleted appointments, and missing appointments
- [x] All 89 non-AI specs pass (`bundle exec rspec` — 3 AI booking failures require a live API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)