### PR TITLE
Add chat messaging, AI simulation, invitations and notifications

### DIFF
--- a/app/controllers/api/ai_booking_controller.rb
+++ b/app/controllers/api/ai_booking_controller.rb
@@ -10,15 +10,16 @@ module Api
       messages  = params[:messages].map { |m| { role: m[:role], content: m[:content] } }
       timezone  = params[:timezone].presence || 'UTC'
 
+      @conversation_id = nil
       anthropic = Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY'])
 
       loop do
         response = anthropic.messages(parameters: {
-          model:     'claude-sonnet-4-6',
+          model:      'claude-sonnet-4-6',
           max_tokens: 1024,
-          system:    system_prompt(profile, is_client, timezone),
-          messages:  messages,
-          tools:     booking_tools(is_client, timezone)
+          system:     system_prompt(profile, is_client, timezone),
+          messages:   messages,
+          tools:      booking_tools(is_client, timezone)
         })
 
         tool_uses = response['content'].select { |b| b['type'] == 'tool_use' }
@@ -31,7 +32,7 @@ module Api
           ]
         else
           text = response['content'].find { |b| b['type'] == 'text' }&.fetch('text', '')
-          return render json: { message: text }
+          return render json: { message: text, conversation_id: @conversation_id }
         end
       end
     end
@@ -42,7 +43,7 @@ module Api
       if is_client
         <<~PROMPT
           You are a friendly AI booking assistant for a disability support platform.
-          You help clients find and book appointments with support workers.
+          You help clients find support workers and send them appointment invitations.
 
           The client you are assisting:
           - Name: #{profile.first_name} #{profile.last_name}
@@ -55,8 +56,8 @@ module Api
           1. Understand what the client needs
           2. Call get_support_workers to find suitable workers
           3. Present 2-3 options with a brief reason each is a good match
-          4. Once the client selects a worker and provides a date, time and duration, call create_appointment
-          5. Confirm the booking details to the client
+          4. Once the client selects a worker and provides a date, time and duration, call send_invitation
+          5. Let the client know their invitation has been sent and they will be taken to the chat to await the worker's response
 
           Be warm, concise and professional. Today's date is #{Date.today}.
           The client's timezone is #{timezone}. Always include the UTC offset in the ISO 8601 datetime.
@@ -64,7 +65,7 @@ module Api
       else
         <<~PROMPT
           You are a friendly AI booking assistant for a disability support platform.
-          You help support workers find and book appointments with clients.
+          You help support workers find clients and send them appointment invitations.
 
           The support worker you are assisting:
           - Name: #{profile.first_name} #{profile.last_name}
@@ -74,8 +75,8 @@ module Api
           When booking:
           1. Understand which client they want to book with or what kind of client they are looking for
           2. Call get_clients to find suitable clients
-          3. Once they select a client and provide a date, time and duration, call create_appointment
-          4. Confirm the booking details
+          3. Once they select a client and provide a date, time and duration, call send_invitation
+          4. Let the support worker know the invitation has been sent and they will be taken to the chat
 
           Be warm, concise and professional. Today's date is #{Date.today}.
           The support worker's timezone is #{timezone}. Always include the UTC offset in the ISO 8601 datetime.
@@ -100,12 +101,12 @@ module Api
             }
           },
           {
-            name: 'create_appointment',
-            description: 'Book an appointment between the current client and a support worker.',
+            name: 'send_invitation',
+            description: 'Send a pending appointment invitation to a support worker. Creates a conversation and a pending appointment that the support worker must approve.',
             input_schema: {
               type: 'object',
               properties: {
-                support_worker_id: { type: 'integer', description: 'ID of the support worker to book' },
+                support_worker_id: { type: 'integer', description: 'ID of the support worker to invite' },
                 date:              { type: 'string',  description: date_desc },
                 duration:          { type: 'integer', description: 'Duration in minutes' },
                 location:          { type: 'string',  description: 'Location of the appointment' },
@@ -128,12 +129,12 @@ module Api
             }
           },
           {
-            name: 'create_appointment',
-            description: 'Book an appointment between the current support worker and a client.',
+            name: 'send_invitation',
+            description: 'Send a pending appointment invitation to a client. Creates a conversation and a pending appointment that the client can view.',
             input_schema: {
               type: 'object',
               properties: {
-                client_id: { type: 'integer', description: 'ID of the client to book' },
+                client_id: { type: 'integer', description: 'ID of the client to invite' },
                 date:      { type: 'string',  description: date_desc },
                 duration:  { type: 'integer', description: 'Duration in minutes' },
                 location:  { type: 'string',  description: 'Location of the appointment' },
@@ -150,7 +151,7 @@ module Api
       result = case tool_use['name']
                when 'get_support_workers' then run_get_support_workers(tool_use['input']['keyword'])
                when 'get_clients'         then run_get_clients(tool_use['input']['keyword'])
-               when 'create_appointment'  then run_create_appointment(tool_use['input'], profile, is_client)
+               when 'send_invitation'     then run_send_invitation(tool_use['input'], profile, is_client)
                else { error: "Unknown tool: #{tool_use['name']}" }
                end
 
@@ -185,19 +186,29 @@ module Api
       end
     end
 
-    def run_create_appointment(input, profile, is_client)
-      attrs = {
-        date:     input['date'],
-        duration: input['duration'],
-        location: input['location'],
-        notes:    input['notes']
-      }
-      attrs[:client_id]         = is_client ? profile.id : input['client_id']
-      attrs[:support_worker_id] = is_client ? input['support_worker_id'] : profile.id
+    def run_send_invitation(input, profile, is_client)
+      client_id         = is_client ? profile.id : input['client_id']
+      support_worker_id = is_client ? input['support_worker_id'] : profile.id
 
-      appointment = Appointment.new(attrs)
+      conversation = Conversation.find_or_create_by(
+        client_id: client_id,
+        support_worker_id: support_worker_id
+      )
+      @conversation_id = conversation.id
+
+      appointment = Appointment.new(
+        date:             input['date'],
+        duration:         input['duration'],
+        location:         input['location'],
+        notes:            input['notes'],
+        client_id:        client_id,
+        support_worker_id: support_worker_id,
+        status:           'pending',
+        conversation_id:  conversation.id
+      )
+
       if appointment.save
-        { success: true, appointment_id: appointment.id }
+        { success: true, appointment_id: appointment.id, conversation_id: conversation.id }
       else
         { success: false, errors: appointment.errors.full_messages }
       end

--- a/app/controllers/api/ai_booking_controller.rb
+++ b/app/controllers/api/ai_booking_controller.rb
@@ -56,16 +56,15 @@ module Api
           1. Understand what the client needs
           2. Call get_support_workers to find suitable workers
           3. Present 2-3 options with a brief reason each is a good match
-          4. Once the client selects a worker and provides a date, time and duration, call send_invitation
-          5. Let the client know their invitation has been sent and they will be taken to the chat to await the worker's response
+          4. Once the client selects a worker, call open_conversation to start a chat with them
+          5. Let the client know they've been connected and can now chat and send an invitation directly from the conversation
 
           Be warm, concise and professional. Today's date is #{Date.today}.
-          The client's timezone is #{timezone}. Always include the UTC offset in the ISO 8601 datetime.
         PROMPT
       else
         <<~PROMPT
           You are a friendly AI booking assistant for a disability support platform.
-          You help support workers find clients and send them appointment invitations.
+          You help support workers find clients and connect with them.
 
           The support worker you are assisting:
           - Name: #{profile.first_name} #{profile.last_name}
@@ -73,20 +72,28 @@ module Api
           - Location: #{profile.location.presence || 'Not specified'}
 
           When booking:
-          1. Understand which client they want to book with or what kind of client they are looking for
+          1. Understand which client they want to connect with or what kind of client they are looking for
           2. Call get_clients to find suitable clients
-          3. Once they select a client and provide a date, time and duration, call send_invitation
-          4. Let the support worker know the invitation has been sent and they will be taken to the chat
+          3. Once they select a client, call open_conversation to start a chat with them
+          4. Let the support worker know they've been connected and can now message and send an invitation from the chat
 
           Be warm, concise and professional. Today's date is #{Date.today}.
-          The support worker's timezone is #{timezone}. Always include the UTC offset in the ISO 8601 datetime.
         PROMPT
       end
     end
 
-    def booking_tools(is_client, timezone = 'UTC')
-      offset_example = '+10:00'
-      date_desc = "ISO 8601 datetime with UTC offset for the user's timezone (#{timezone}), e.g. 2026-05-12T09:00:00#{offset_example}"
+    def booking_tools(is_client, _timezone = 'UTC')
+      open_conv_tool = {
+        name: 'open_conversation',
+        description: 'Open a conversation with the selected person. Call this once the user has chosen who they want to connect with. This will take the user directly to the chat.',
+        input_schema: {
+          type: 'object',
+          properties: {
+            person_id: { type: 'integer', description: is_client ? 'ID of the support worker to connect with' : 'ID of the client to connect with' }
+          },
+          required: %w[person_id]
+        }
+      }
 
       if is_client
         [
@@ -100,21 +107,7 @@ module Api
               }
             }
           },
-          {
-            name: 'send_invitation',
-            description: 'Send a pending appointment invitation to a support worker. Creates a conversation and a pending appointment that the support worker must approve.',
-            input_schema: {
-              type: 'object',
-              properties: {
-                support_worker_id: { type: 'integer', description: 'ID of the support worker to invite' },
-                date:              { type: 'string',  description: date_desc },
-                duration:          { type: 'integer', description: 'Duration in minutes' },
-                location:          { type: 'string',  description: 'Location of the appointment' },
-                notes:             { type: 'string',  description: 'Optional notes' }
-              },
-              required: %w[support_worker_id date duration location]
-            }
-          }
+          open_conv_tool
         ]
       else
         [
@@ -128,21 +121,7 @@ module Api
               }
             }
           },
-          {
-            name: 'send_invitation',
-            description: 'Send a pending appointment invitation to a client. Creates a conversation and a pending appointment that the client can view.',
-            input_schema: {
-              type: 'object',
-              properties: {
-                client_id: { type: 'integer', description: 'ID of the client to invite' },
-                date:      { type: 'string',  description: date_desc },
-                duration:  { type: 'integer', description: 'Duration in minutes' },
-                location:  { type: 'string',  description: 'Location of the appointment' },
-                notes:     { type: 'string',  description: 'Optional notes' }
-              },
-              required: %w[client_id date duration location]
-            }
-          }
+          open_conv_tool
         ]
       end
     end
@@ -151,7 +130,7 @@ module Api
       result = case tool_use['name']
                when 'get_support_workers' then run_get_support_workers(tool_use['input']['keyword'])
                when 'get_clients'         then run_get_clients(tool_use['input']['keyword'])
-               when 'send_invitation'     then run_send_invitation(tool_use['input'], profile, is_client)
+               when 'open_conversation'   then run_open_conversation(tool_use['input']['person_id'], profile, is_client)
                else { error: "Unknown tool: #{tool_use['name']}" }
                end
 
@@ -186,9 +165,9 @@ module Api
       end
     end
 
-    def run_send_invitation(input, profile, is_client)
-      client_id         = is_client ? profile.id : input['client_id']
-      support_worker_id = is_client ? input['support_worker_id'] : profile.id
+    def run_open_conversation(person_id, profile, is_client)
+      client_id         = is_client ? profile.id : person_id
+      support_worker_id = is_client ? person_id   : profile.id
 
       conversation = Conversation.find_or_create_by(
         client_id: client_id,
@@ -196,22 +175,7 @@ module Api
       )
       @conversation_id = conversation.id
 
-      appointment = Appointment.new(
-        date:             input['date'],
-        duration:         input['duration'],
-        location:         input['location'],
-        notes:            input['notes'],
-        client_id:        client_id,
-        support_worker_id: support_worker_id,
-        status:           'pending',
-        conversation_id:  conversation.id
-      )
-
-      if appointment.save
-        { success: true, appointment_id: appointment.id, conversation_id: conversation.id }
-      else
-        { success: false, errors: appointment.errors.full_messages }
-      end
+      { success: true, conversation_id: conversation.id }
     end
   end
 end

--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -14,13 +14,13 @@ module Api
 
     def index
       appointments = if current_user.client
-        Appointment.approved.where(client_id: current_user.client.id)
+        Appointment.approved.where(client_id: current_user.client.id).includes(:client, :support_worker)
       elsif current_user.support_worker
-        Appointment.approved.where(support_worker_id: current_user.support_worker.id)
+        Appointment.approved.where(support_worker_id: current_user.support_worker.id).includes(:client, :support_worker)
       else
         []
       end
-      render json: appointments, include: [:client, :support_worker]
+      render json: appointments.as_json(include: [:client, :support_worker])
     end
 
     def pending
@@ -92,9 +92,9 @@ module Api
       appt_time = appointment.date.strftime('%-d %B at %-I:%M %p') rescue appointment.date.to_s
 
       text = if status == 'approved'
-        "✓ #{actor_name} has accepted the appointment invitation for #{appt_time}."
+        "[SYS]✓ Appointment confirmed for #{appt_time}."
       else
-        "#{actor_name} has declined the appointment invitation for #{appt_time}."
+        "[SYS] Appointment declined for #{appt_time}."
       end
 
       conversation.messages.create!(

--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -14,13 +14,54 @@ module Api
 
     def index
       appointments = if current_user.client
-        Appointment.active.where(client_id: current_user.client.id)
+        Appointment.approved.where(client_id: current_user.client.id)
       elsif current_user.support_worker
-        Appointment.active.where(support_worker_id: current_user.support_worker.id)
+        Appointment.approved.where(support_worker_id: current_user.support_worker.id)
       else
         []
       end
       render json: appointments, include: [:client, :support_worker]
+    end
+
+    def pending
+      appointments = if current_user.support_worker
+        Appointment.pending.where(support_worker_id: current_user.support_worker.id).includes(:client, :support_worker)
+      elsif current_user.client
+        Appointment.pending.where(client_id: current_user.client.id).includes(:client, :support_worker)
+      else
+        []
+      end
+      render json: appointments.as_json(include: [:client, :support_worker])
+    end
+
+    def recently_accepted
+      appointments = if current_user.client
+        Appointment.where(client_id: current_user.client.id, status: 'approved')
+                   .where('updated_at > ?', 24.hours.ago)
+                   .includes(:client, :support_worker)
+      elsif current_user.support_worker
+        Appointment.where(support_worker_id: current_user.support_worker.id, status: 'approved')
+                   .where('updated_at > ?', 24.hours.ago)
+                   .includes(:client, :support_worker)
+      else
+        []
+      end
+      render json: appointments.as_json(include: [:client, :support_worker])
+    end
+
+    def approve
+      appointment = Appointment.find(params[:id])
+      appointment.update!(status: 'approved')
+      schedule_reminder(appointment)
+      post_status_message(appointment, 'approved')
+      render json: appointment.as_json(include: [:client, :support_worker])
+    end
+
+    def decline
+      appointment = Appointment.find(params[:id])
+      appointment.update!(status: 'declined')
+      post_status_message(appointment, 'declined')
+      render json: appointment.as_json(include: [:client, :support_worker])
     end
     
     def update
@@ -41,6 +82,28 @@ module Api
 
     private
 
+    def post_status_message(appointment, status)
+      return unless appointment.conversation_id
+
+      conversation = Conversation.find(appointment.conversation_id)
+      actor = current_user.support_worker || current_user.client
+      sender_type = current_user.support_worker ? 'support_worker' : 'client'
+      actor_name = "#{actor.first_name} #{actor.last_name}"
+      appt_time = appointment.date.strftime('%-d %B at %-I:%M %p') rescue appointment.date.to_s
+
+      text = if status == 'approved'
+        "✓ #{actor_name} has accepted the appointment invitation for #{appt_time}."
+      else
+        "#{actor_name} has declined the appointment invitation for #{appt_time}."
+      end
+
+      conversation.messages.create!(
+        content: text,
+        sender_type: sender_type,
+        sender_id: actor.id
+      )
+    end
+
     def schedule_reminder(appointment)
       reminder_time = appointment.date - 24.hours
       return unless reminder_time > Time.current
@@ -48,7 +111,7 @@ module Api
     end
 
     def appointment_params
-      params.require(:appointment).permit(:date, :duration, :location, :notes, :client_id, :support_worker_id)
+      params.require(:appointment).permit(:date, :duration, :location, :notes, :client_id, :support_worker_id, :status, :conversation_id)
     end
   end
 end

--- a/app/controllers/api/conversations_controller.rb
+++ b/app/controllers/api/conversations_controller.rb
@@ -1,0 +1,185 @@
+module Api
+  class ConversationsController < ApplicationController
+    def index
+      conversations = if current_user.client
+        Conversation.where(client_id: current_user.client.id).includes(:support_worker, :messages)
+      elsif current_user.support_worker
+        Conversation.where(support_worker_id: current_user.support_worker.id).includes(:client, :messages)
+      else
+        []
+      end
+      render json: conversations.as_json(
+        include: {
+          client: {},
+          support_worker: {},
+          messages: { only: %i[id content sender_type sender_id created_at] },
+        }
+      )
+    end
+
+    def show
+      conversation = Conversation.includes(:client, :support_worker, :messages).find(params[:id])
+      render json: conversation.as_json(
+        include: {
+          client: {},
+          support_worker: {},
+          messages: { only: %i[id content sender_type sender_id created_at] },
+          appointments: { only: %i[id date duration location notes status] },
+        }
+      )
+    end
+
+    def create
+      conversation = if current_user.client
+        Conversation.find_or_create_by(
+          client_id: current_user.client.id,
+          support_worker_id: params[:support_worker_id]
+        )
+      elsif current_user.support_worker
+        Conversation.find_or_create_by(
+          client_id: params[:client_id],
+          support_worker_id: current_user.support_worker.id
+        )
+      end
+      render json: conversation, status: :created
+    end
+
+    def suggest_booking
+      conversation = Conversation.includes(:messages).find(params[:id])
+
+      transcript = conversation.messages.order(:created_at).last(12).map do |m|
+        "[#{m.sender_type}]: #{m.content}"
+      end.join("\n")
+
+      return render json: {} if transcript.blank?
+
+      anthropic = Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY'])
+      response = anthropic.messages(parameters: {
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 200,
+        system: "Extract appointment booking details from this conversation transcript. Return ONLY valid JSON with these exact keys (use null for anything not mentioned): {\"date\": \"YYYY-MM-DD\", \"time\": \"HH:MM\", \"duration\": <minutes as integer or null>, \"location\": \"string or null\", \"notes\": \"string or null\"}. Today is #{Date.today} (#{Date.today.strftime('%A')}). Resolve relative days like 'next Tuesday' or 'tomorrow' to absolute YYYY-MM-DD dates. Do not wrap in markdown.",
+        messages: [{ role: 'user', content: transcript }],
+      })
+
+      text = response['content'].first['text'].strip.gsub(/\A```(?:json)?\n?/, '').gsub(/\n?```\z/, '').strip
+
+      begin
+        render json: JSON.parse(text)
+      rescue JSON::ParserError
+        render json: {}
+      end
+    end
+
+    def ai_respond
+      conversation = Conversation.includes(:client, :support_worker, :messages, :appointments).find(params[:id])
+
+      is_client = current_user.client.present?
+      simulated_role = is_client ? 'support_worker' : 'client'
+      simulated_person = is_client ? conversation.support_worker : conversation.client
+      current_person  = is_client ? conversation.client : conversation.support_worker
+
+      pending_appt = conversation.appointments.find { |a| a.status == 'pending' }
+
+      history = conversation.messages.order(:created_at).map do |m|
+        role = m.sender_type == simulated_role ? 'assistant' : 'user'
+        { role: role, content: m.content }
+      end
+
+      return render json: { error: 'No message to respond to' }, status: :unprocessable_entity if history.empty?
+
+      # In a continuation flow the last saved message is from the AI — add a silent nudge so the API call is valid
+      history << { role: 'user', content: '[continue]' } if history.last[:role] == 'assistant'
+
+      persona = build_persona(simulated_person, simulated_role, current_person, pending_appt)
+
+      anthropic = Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY'])
+      response = anthropic.messages(parameters: {
+        model: 'claude-sonnet-4-6',
+        max_tokens: 400,
+        system: persona,
+        messages: history,
+      })
+
+      reply_text = response['content'].first['text'].strip
+
+      # Parse optional JSON action from Claude
+      action = nil
+      reply_clean = reply_text
+      if reply_text.start_with?('{')
+        begin
+          parsed = JSON.parse(reply_text)
+          reply_clean = parsed['message']
+          action = parsed['action']
+        rescue JSON::ParserError
+        end
+      end
+
+      # Strip [CONTINUE] signal and flag it
+      will_continue = reply_clean.include?('[CONTINUE]')
+      reply_clean = reply_clean.gsub('[CONTINUE]', '').strip
+
+      msg = conversation.messages.create!(
+        content: reply_clean,
+        sender_type: simulated_role,
+        sender_id: simulated_person.id
+      )
+
+      # Handle approve/decline action
+      if pending_appt && action == 'approve'
+        pending_appt.update!(status: 'approved')
+        schedule_reminder(pending_appt)
+      elsif pending_appt && action == 'decline'
+        pending_appt.update!(status: 'declined')
+      end
+
+      render json: {
+        message: msg.as_json(only: %i[id content sender_type sender_id created_at]),
+        action: action,
+        appointment: pending_appt&.reload&.as_json(only: %i[id status date duration location notes]),
+        continue: will_continue,
+      }
+    end
+
+    private
+
+    def build_persona(simulated_person, simulated_role, current_person, pending_appt)
+      name = "#{simulated_person.first_name} #{simulated_person.last_name}"
+      other_name = current_person.first_name
+
+      base = if simulated_role == 'support_worker'
+        <<~P
+          You are #{name}, a support worker in a disability support app. You are having a genuine chat with a client named #{other_name}.
+          Your details — Location: #{simulated_person.location}, Bio: #{simulated_person.bio.presence || 'experienced support worker'}.
+          Be warm, professional and concise. Ask relevant questions about their needs. Keep replies to 1-3 sentences.
+          IMPORTANT: If you intend to immediately follow up with more content (e.g. you just promised a list, ideas or information), end your message with [CONTINUE] on its own line and you will be prompted again. Do NOT say "give me a moment" or "I'll follow up" without including [CONTINUE]. If you have the content ready, include it now instead.
+        P
+      else
+        <<~P
+          You are #{name}, a client in a disability support app. You are having a genuine chat with your support worker #{other_name}.
+          Be natural and conversational. Keep replies to 1-3 sentences.
+          IMPORTANT: If you intend to immediately follow up with more content, end your message with [CONTINUE] on its own line.
+        P
+      end
+
+      if pending_appt
+        appt_time = Time.parse(pending_appt.date.to_s).strftime('%A, %b %-d at %-I:%M %p') rescue pending_appt.date.to_s
+        base += <<~P
+
+          There is a pending appointment invitation for #{appt_time} (#{pending_appt.duration} min, #{pending_appt.location}).
+          If it suits you, respond naturally and include a JSON decision at the end of your reply like this:
+          {"message": "your reply here", "action": "approve"}
+          Or to decline: {"message": "your reply here", "action": "decline"}
+          Only include the JSON if you are making a decision about the appointment.
+        P
+      end
+
+      base
+    end
+
+    def schedule_reminder(appointment)
+      reminder_time = appointment.date - 24.hours
+      return unless reminder_time > Time.current
+      AppointmentReminderJob.set(wait_until: reminder_time).perform_later(appointment.id)
+    end
+  end
+end

--- a/app/controllers/api/conversations_controller.rb
+++ b/app/controllers/api/conversations_controller.rb
@@ -104,12 +104,13 @@ module Api
 
       # Parse optional JSON action from Claude
       action = nil
+      parsed_action = nil
       reply_clean = reply_text
       if reply_text.start_with?('{')
         begin
-          parsed = JSON.parse(reply_text)
-          reply_clean = parsed['message']
-          action = parsed['action']
+          parsed_action = JSON.parse(reply_text)
+          reply_clean = parsed_action['message']
+          action = parsed_action['action']
         rescue JSON::ParserError
         end
       end
@@ -125,17 +126,29 @@ module Api
       )
 
       # Handle approve/decline action
+      affected_appt = pending_appt
       if pending_appt && action == 'approve'
         pending_appt.update!(status: 'approved')
         schedule_reminder(pending_appt)
       elsif pending_appt && action == 'decline'
         pending_appt.update!(status: 'declined')
+      elsif action == 'send_invitation' && parsed_action
+        affected_appt = conversation.appointments.create!(
+          date:             parsed_action['date'],
+          duration:         parsed_action['duration'],
+          location:         parsed_action['location'],
+          notes:            parsed_action['notes'],
+          client_id:        conversation.client_id,
+          support_worker_id: conversation.support_worker_id,
+          status:           'pending',
+          conversation_id:  conversation.id
+        )
       end
 
       render json: {
         message: msg.as_json(only: %i[id content sender_type sender_id created_at]),
         action: action,
-        appointment: pending_appt&.reload&.as_json(only: %i[id status date duration location notes]),
+        appointment: affected_appt&.reload&.as_json(only: %i[id status date duration location notes]),
         continue: will_continue,
       }
     end
@@ -146,18 +159,27 @@ module Api
       name = "#{simulated_person.first_name} #{simulated_person.last_name}"
       other_name = current_person.first_name
 
+      today = Date.today.strftime('%A, %-d %B %Y')
+
       base = if simulated_role == 'support_worker'
         <<~P
-          You are #{name}, a support worker in a disability support app. You are having a genuine chat with a client named #{other_name}.
+          You are #{name} (the SUPPORT WORKER). You are chatting with #{other_name}, who is your CLIENT.
+          CRITICAL: You are #{name}. The other person is #{other_name}. Never call #{other_name} by your own name (#{simulated_person.first_name}).
           Your details — Location: #{simulated_person.location}, Bio: #{simulated_person.bio.presence || 'experienced support worker'}.
-          Be warm, professional and concise. Ask relevant questions about their needs. Keep replies to 1-3 sentences.
-          IMPORTANT: If you intend to immediately follow up with more content (e.g. you just promised a list, ideas or information), end your message with [CONTINUE] on its own line and you will be prompted again. Do NOT say "give me a moment" or "I'll follow up" without including [CONTINUE]. If you have the content ready, include it now instead.
+          Be warm, professional and concise. Keep replies to 1-3 sentences.
+          If you intend to immediately follow up with more content, end your message with [CONTINUE] on its own line.
         P
       else
         <<~P
-          You are #{name}, a client in a disability support app. You are having a genuine chat with your support worker #{other_name}.
+          You are #{name} (the CLIENT). You are chatting with #{other_name}, who is your SUPPORT WORKER.
+          CRITICAL: You are #{name}. The other person is #{other_name}. Never call #{other_name} by your own name (#{simulated_person.first_name}).
           Be natural and conversational. Keep replies to 1-3 sentences.
-          IMPORTANT: If you intend to immediately follow up with more content, end your message with [CONTINUE] on its own line.
+          If you intend to immediately follow up with more content, end your message with [CONTINUE] on its own line.
+          Today is #{today}.
+          When you and #{other_name} have clearly agreed on a date, time, location and duration for an appointment,
+          proactively offer to send a formal invitation. Once confirmed, respond with ONLY this JSON (no other text):
+          {"message": "your friendly confirmation message", "action": "send_invitation", "date": "YYYY-MM-DDTHH:MM:00+HH:MM", "duration": <minutes>, "location": "place"}
+          Use the actual agreed date, time and location. Include the correct UTC offset for Sydney time (+10:00).
         P
       end
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class MessagesController < ApplicationController
+    def index
+      conversation = Conversation.find(params[:conversation_id])
+      render json: conversation.messages.as_json(only: %i[id content sender_type sender_id created_at])
+    end
+
+    def create
+      conversation = Conversation.find(params[:conversation_id])
+      sender_type = current_user.client ? 'client' : 'support_worker'
+      sender_id   = current_user.client&.id || current_user.support_worker&.id
+      message = conversation.messages.create!(
+        content: params[:content],
+        sender_type: sender_type,
+        sender_id: sender_id
+      )
+      render json: message.as_json(only: %i[id content sender_type sender_id created_at]), status: :created
+    end
+  end
+end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -1,0 +1,48 @@
+module Api
+  class NotificationsController < ApplicationController
+    def index
+      if current_user.client
+        person = current_user.client
+        role = 'client'
+        other_role = 'support_worker'
+      elsif current_user.support_worker
+        person = current_user.support_worker
+        role = 'support_worker'
+        other_role = 'client'
+      else
+        return render json: { unread_messages: 0, pending_invitations: 0, total: 0 }
+      end
+
+      conversations = if role == 'client'
+        Conversation.where(client_id: person.id).includes(:messages)
+      else
+        Conversation.where(support_worker_id: person.id).includes(:messages)
+      end
+
+      unread = conversations.count do |conv|
+        last = conv.messages.sort_by(&:created_at).last
+        last && last.sender_type == other_role
+      end
+
+      pending_invitations = if role == 'support_worker'
+        Appointment.where(support_worker_id: person.id, status: 'pending').count
+      else
+        Appointment.where(client_id: person.id, status: 'pending').count
+      end
+
+      recently_accepted = if role == 'client'
+        Appointment.where(client_id: person.id, status: 'approved')
+                   .where('updated_at > ?', 24.hours.ago).count
+      else
+        0
+      end
+
+      render json: {
+        unread_messages: unread,
+        pending_invitations: pending_invitations,
+        recently_accepted: recently_accepted,
+        total: unread + pending_invitations + recently_accepted,
+      }
+    end
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -2,6 +2,10 @@ class Appointment < ApplicationRecord
   belongs_to :client
   belongs_to :support_worker
 
+  belongs_to :conversation, optional: true
+
   scope :active, -> { where(deleted_at: nil) }
+  scope :approved, -> { active.where(status: 'approved') }
+  scope :pending, -> { active.where(status: 'pending') }
   validates :date, presence: true
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,0 +1,9 @@
+class Conversation < ApplicationRecord
+  belongs_to :client
+  belongs_to :support_worker
+  has_many :messages, -> { order(:created_at) }
+  has_many :appointments
+
+  def find_or_build_with(other_id, current_profile)
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,5 @@
+class Message < ApplicationRecord
+  belongs_to :conversation
+  validates :content, presence: true
+  validates :sender_type, inclusion: { in: %w[client support_worker] }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,27 @@ Rails.application.routes.draw do
     # root "posts#index"
     resources :users, only: [:create]
     resources :clients
-    resources :appointments
+    resources :appointments do
+      collection do
+        get :pending
+        get :recently_accepted
+      end
+      member do
+        patch :approve
+        patch :decline
+      end
+    end
+    get 'notifications', to: 'notifications#index'
+    resources :conversations, only: [:index, :show, :create] do
+      resources :messages, only: [:index, :create]
+      member do
+        post :ai_respond
+        get :suggest_booking
+      end
+    end
     resources :visit_reports
     post 'ai_booking/chat', to: 'ai_booking#chat'
+    post 'chat_simulation', to: 'chat_simulation#simulate'
     get 'dashboard', to: 'dashboard#show'
     resources :support_workers
   end

--- a/db/migrate/20260506232243_create_conversations.rb
+++ b/db/migrate/20260506232243_create_conversations.rb
@@ -1,0 +1,10 @@
+class CreateConversations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :conversations do |t|
+      t.integer :client_id
+      t.integer :support_worker_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260506232245_create_messages.rb
+++ b/db/migrate/20260506232245_create_messages.rb
@@ -1,0 +1,12 @@
+class CreateMessages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :messages do |t|
+      t.integer :conversation_id
+      t.string :sender_type
+      t.integer :sender_id
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260506232248_add_status_and_conversation_to_appointments.rb
+++ b/db/migrate/20260506232248_add_status_and_conversation_to_appointments.rb
@@ -1,0 +1,6 @@
+class AddStatusAndConversationToAppointments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :appointments, :status, :string, default: 'approved', null: false
+    add_column :appointments, :conversation_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_29_004359) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_06_232248) do
   create_table "appointments", force: :cascade do |t|
     t.datetime "date"
     t.integer "duration"
@@ -22,6 +22,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_29_004359) do
     t.datetime "updated_at", null: false
     t.integer "support_worker_id"
     t.datetime "deleted_at"
+    t.string "status", default: "approved", null: false
+    t.integer "conversation_id"
   end
 
   create_table "clients", force: :cascade do |t|
@@ -44,6 +46,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_29_004359) do
     t.string "emergency_contact_first_name"
     t.string "emergency_contact_last_name"
     t.index ["user_id"], name: "index_clients_on_user_id"
+  end
+
+  create_table "conversations", force: :cascade do |t|
+    t.integer "client_id"
+    t.integer "support_worker_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.integer "conversation_id"
+    t.string "sender_type"
+    t.integer "sender_id"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "specializations", force: :cascade do |t|


### PR DESCRIPTION
## Summary

- **Conversations & messages** — new models and full CRUD API nested under conversations
- **AI simulation** — `ai_respond` endpoint has Claude play the opposite party; parses optional `{"message": "...", "action": "approve/decline"}` JSON for appointment decisions; supports `[CONTINUE]` token for automatic follow-up messages
- **suggest_booking** — uses Claude Haiku to extract appointment details from conversation history for form pre-fill
- **Appointment invitation flow** — `status` column (pending/approved/declined), `approve` and `decline` member actions that auto-post a message to the linked conversation
- **Notifications endpoint** — returns unread message count, pending invitation count, and recently accepted count per role
- **Booking agent** — updated to create pending invitations via conversations; returns `conversation_id` for frontend navigation

## Test plan

- [ ] Run `db:migrate` — three new migrations (conversations, messages, appointment status/conversation_id)
- [ ] `POST /api/conversations` → creates or finds conversation between client and support worker
- [ ] `POST /api/conversations/:id/messages` → saves message, `POST /api/conversations/:id/ai_respond` → Claude responds as opposite party
- [ ] `GET /api/appointments/pending` and `recently_accepted` return correct scoped results per role
- [ ] `PATCH /api/appointments/:id/approve` posts automated message to conversation
- [ ] `GET /api/notifications` returns correct counts for both client and support worker roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)