### PR TITLE
Block pending workers from client data and tighten vetting validation

### DIFF
--- a/app/controllers/api/admin_controller.rb
+++ b/app/controllers/api/admin_controller.rb
@@ -1,0 +1,36 @@
+module Api
+  class AdminController < ApplicationController
+    before_action :require_admin
+
+    def applications
+      workers = SupportWorker.pending_approval.includes(:user, :specializations)
+      render json: workers.as_json(include: { specializations: {}, user: { only: [:email] } },
+                                   methods: [:status, :police_check_number, :wwcc_number, :check_notes, :agent_recommendation])
+    end
+
+    def approve
+      worker = SupportWorker.find(params[:id])
+      worker.update!(status: 'approved')
+      render json: { message: 'Support worker approved' }
+    end
+
+    def reject
+      worker = SupportWorker.find(params[:id])
+      worker.update!(status: 'rejected')
+      render json: { message: 'Support worker rejected' }
+    end
+
+    def appointments
+      appts = Appointment.includes(:client, :support_worker).order(date: :asc)
+      render json: appts.as_json(include: [:client, :support_worker])
+    end
+
+    private
+
+    def require_admin
+      unless current_user&.is_admin
+        render json: { error: 'Forbidden' }, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/ai_booking_controller.rb
+++ b/app/controllers/api/ai_booking_controller.rb
@@ -3,7 +3,12 @@ module Api
     def chat
       return render json: { error: 'Must be logged in' }, status: :unauthorized unless current_user
 
-      profile = current_user.client || current_user.support_worker
+      worker = current_user.support_worker
+      if worker && worker.status != 'approved'
+        return render json: { error: 'Your account is pending approval' }, status: :forbidden
+      end
+
+      profile = current_user.client || worker
       return render json: { error: 'No profile found' }, status: :forbidden unless profile
 
       is_client = current_user.client.present?

--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -2,7 +2,8 @@ module Api
   class AppointmentsController < ApplicationController
     def create
       return render json: { errors: 'Must be logged in to book appointments' }, status: :unauthorized unless current_user
-      return render json: { errors: 'Only clients and support workers can book appointments' }, status: :forbidden unless current_user.client || current_user.support_worker
+      approved_worker = current_user.support_worker&.status == 'approved'
+      return render json: { errors: 'Only clients and approved support workers can book appointments' }, status: :forbidden unless current_user.client || approved_worker
       @appointment = Appointment.new(appointment_params)
       if @appointment.save
         schedule_reminder(@appointment)
@@ -15,7 +16,7 @@ module Api
     def index
       appointments = if current_user.client
         Appointment.approved.where(client_id: current_user.client.id).includes(:client, :support_worker)
-      elsif current_user.support_worker
+      elsif current_user.support_worker&.status == 'approved'
         Appointment.approved.where(support_worker_id: current_user.support_worker.id).includes(:client, :support_worker)
       else
         []

--- a/app/controllers/api/clients_controller.rb
+++ b/app/controllers/api/clients_controller.rb
@@ -1,13 +1,16 @@
 module Api
   class ClientsController < ApplicationController
     def index
-      return render json: { error: 'Forbidden' }, status: :forbidden unless current_user&.support_worker
+      worker = current_user&.support_worker
+      return render json: { error: 'Forbidden' }, status: :forbidden unless worker&.status == 'approved'
       render json: Client.all
     end
 
     def show
       client = Client.find(params[:id])
-      unless current_user&.support_worker || current_user&.client&.id == client.id
+      worker = current_user&.support_worker
+      approved_worker = worker&.status == 'approved'
+      unless approved_worker || current_user&.client&.id == client.id
         return render json: { error: 'Forbidden' }, status: :forbidden
       end
       render json: client

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -6,7 +6,7 @@ module Api
       if user.valid_password?(params[:password])
         session[:user_id] = user.id       
         render json: {
-          user: user,
+          user: current_user.as_json(only: %i[id email is_admin]),
           client: user.client,
           support_worker: user.support_worker
         }, status: :ok
@@ -18,7 +18,7 @@ module Api
     def logged_in_user
       if current_user
         render json: {
-            user: current_user,
+            user: current_user.as_json(only: %i[id email is_admin]),
             client: current_user.client,
             support_worker: current_user.support_worker
           }

--- a/app/controllers/api/support_workers_controller.rb
+++ b/app/controllers/api/support_workers_controller.rb
@@ -1,11 +1,20 @@
 module Api
   class SupportWorkersController < ApplicationController
     def index
-      render json: SupportWorker.includes(:specializations).all, include: :specializations
+      workers = if current_user&.is_admin
+        SupportWorker.includes(:specializations).all
+      else
+        SupportWorker.includes(:specializations).where(status: 'approved')
+      end
+      render json: workers.as_json(include: :specializations)
     end
 
     def show
-      render json: SupportWorker.includes(:specializations).find(params[:id]), include: :specializations
+      worker = SupportWorker.includes(:specializations).find(params[:id])
+      unless current_user&.is_admin || worker.status == 'approved'
+        return render json: { error: 'Not found' }, status: :not_found
+      end
+      render json: worker.as_json(include: :specializations)
     end
 
     def update

--- a/app/controllers/api/vetting_controller.rb
+++ b/app/controllers/api/vetting_controller.rb
@@ -1,0 +1,90 @@
+module Api
+  class VettingController < ApplicationController
+    def chat
+      return render json: { error: 'Unauthorized' }, status: :unauthorized unless current_user
+      worker = current_user.support_worker
+      return render json: { error: 'Forbidden' }, status: :forbidden unless worker
+
+      user_message = params[:message].to_s.strip
+      history = params[:history] || []
+
+      system_prompt = build_vetting_prompt(worker)
+
+      messages = history.map { |m| { role: m['role'], content: m['content'] } }
+      messages << { role: 'user', content: user_message } if user_message.present?
+
+      anthropic = Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY'])
+      response = anthropic.messages(parameters: {
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 400,
+        system: system_prompt,
+        messages: messages,
+      })
+
+      reply_text = response['content'].first['text'].strip
+
+      extracted = nil
+      if reply_text.include?('[VETTING_COMPLETE]')
+        extracted = extract_vetting_data(history + [{ 'role' => 'user', 'content' => user_message }, { 'role' => 'assistant', 'content' => reply_text }])
+        if extracted
+          worker.update!(
+            police_check_number: extracted[:police_check_number],
+            wwcc_number: extracted[:wwcc_number],
+            check_notes: extracted[:notes],
+            agent_recommendation: extracted[:recommendation]
+          )
+        end
+        reply_clean = reply_text.gsub('[VETTING_COMPLETE]', '').strip
+      else
+        reply_clean = reply_text
+      end
+
+      render json: {
+        reply: reply_clean,
+        complete: extracted.present?,
+        recommendation: extracted&.dig(:recommendation),
+      }
+    end
+
+    private
+
+    def build_vetting_prompt(worker)
+      <<~PROMPT
+        You are a vetting assistant for a support worker platform. You are speaking with #{worker.first_name} #{worker.last_name}, who has just signed up as a support worker.
+
+        Your job is to collect their compliance check details:
+        1. Police Check Number (a reference number from their police background check)
+        2. Working With Children Check (WWCC) number
+
+        Be friendly and professional. Ask for one piece of information at a time. If they provide a number, confirm it back to them.
+
+        Once you have BOTH numbers:
+        - Simulate a verification check (always pass for demonstration purposes)
+        - Give a recommendation: "approved" or "needs_review"
+        - End your final message with [VETTING_COMPLETE] on its own line
+
+        Your recommendation should be "approved" if both numbers look like plausible reference numbers (letters/digits, at least 4 characters each), otherwise "needs_review".
+
+        Keep replies concise (1-3 sentences).
+      PROMPT
+    end
+
+    def extract_vetting_data(full_history)
+      transcript = full_history.map { |m| "[#{m['role']}]: #{m['content']}" }.join("\n")
+
+      anthropic = Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY'])
+      response = anthropic.messages(parameters: {
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 200,
+        system: 'Extract vetting data from this conversation. Return ONLY valid JSON: {"police_check_number": "...", "wwcc_number": "...", "recommendation": "approved|needs_review", "notes": "brief summary"}. Use null for missing values.',
+        messages: [{ role: 'user', content: transcript }],
+      })
+
+      text = response['content'].first['text'].strip.gsub(/\A```(?:json)?\n?/, '').gsub(/\n?```\z/, '').strip
+      data = JSON.parse(text)
+      data.transform_keys(&:to_sym)
+    rescue
+      nil
+    end
+  end
+end

--- a/app/controllers/api/vetting_controller.rb
+++ b/app/controllers/api/vetting_controller.rb
@@ -56,14 +56,23 @@ module Api
         1. Police Check Number (a reference number from their police background check)
         2. Working With Children Check (WWCC) number
 
-        Be friendly and professional. Ask for one piece of information at a time. If they provide a number, confirm it back to them.
+        IMPORTANT: The conversation has already started and you have already asked for the Police Check number. Do NOT re-introduce yourself or re-explain the process. Simply continue the conversation naturally from where it left off.
+
+        Be friendly and professional. Ask for one piece of information at a time. If they provide a number, confirm it back to them before moving on.
 
         Once you have BOTH numbers:
         - Simulate a verification check (always pass for demonstration purposes)
         - Give a recommendation: "approved" or "needs_review"
         - End your final message with [VETTING_COMPLETE] on its own line
 
-        Your recommendation should be "approved" if both numbers look like plausible reference numbers (letters/digits, at least 4 characters each), otherwise "needs_review".
+        A plausible reference number must meet ALL of these criteria:
+        - At least 6 characters long
+        - Contains at least one digit (0-9)
+        - Is not a plain dictionary word or name
+
+        If a number does not meet these criteria, tell the worker it doesn't look like a valid reference number and ask them to double-check and provide the correct one. Do not accept it.
+
+        Your recommendation should be "approved" if both numbers are plausible reference numbers, otherwise "needs_review".
 
         Keep replies concise (1-3 sentences).
       PROMPT

--- a/app/models/support_worker.rb
+++ b/app/models/support_worker.rb
@@ -4,4 +4,8 @@ class SupportWorker < ApplicationRecord
   has_and_belongs_to_many :specializations
   validates :first_name, :last_name, :age, :phone, :email, :location, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :status, inclusion: { in: %w[pending approved rejected] }
+
+  scope :approved, -> { where(status: 'approved') }
+  scope :pending_approval, -> { where(status: 'pending') }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,5 +37,12 @@ Rails.application.routes.draw do
     post 'chat_simulation', to: 'chat_simulation#simulate'
     get 'dashboard', to: 'dashboard#show'
     resources :support_workers
+    post 'vetting/chat', to: 'vetting#chat'
+    namespace :admin do
+      get 'applications', to: '/api/admin#applications'
+      patch 'applications/:id/approve', to: '/api/admin#approve', as: :approve_application
+      patch 'applications/:id/reject', to: '/api/admin#reject', as: :reject_application
+      get 'appointments', to: '/api/admin#appointments'
+    end
   end
 end

--- a/db/migrate/20260507100000_add_admin_and_worker_vetting.rb
+++ b/db/migrate/20260507100000_add_admin_and_worker_vetting.rb
@@ -1,0 +1,14 @@
+class AddAdminAndWorkerVetting < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :is_admin, :boolean, default: false, null: false
+
+    add_column :support_workers, :status, :string, default: 'pending', null: false
+    add_column :support_workers, :police_check_number, :string
+    add_column :support_workers, :wwcc_number, :string
+    add_column :support_workers, :check_notes, :text
+    add_column :support_workers, :agent_recommendation, :string
+
+    # Grandfather existing support workers as approved
+    SupportWorker.update_all(status: 'approved')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_06_232248) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_07_100000) do
   create_table "appointments", force: :cascade do |t|
     t.datetime "date"
     t.integer "duration"
@@ -94,6 +94,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_06_232248) do
     t.string "emergency_contact_last_name"
     t.string "emergency_contact_phone"
     t.string "gender"
+    t.string "status", default: "pending", null: false
+    t.string "police_check_number"
+    t.string "wwcc_number"
+    t.text "check_notes"
+    t.string "agent_recommendation"
     t.index ["user_id"], name: "index_support_workers_on_user_id"
   end
 
@@ -110,6 +115,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_06_232248) do
     t.string "first_name"
     t.string "last_name"
     t.string "middle_name"
+    t.boolean "is_admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/ai_booking_controller_spec.rb
+++ b/spec/controllers/ai_booking_controller_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe "AiBookingController", type: :request do
   let(:sw_user) { User.create!(email: 'sw@test.com', password: 'password123', first_name: 'Bob', last_name: 'Brown') }
   let(:support_worker) do
     SupportWorker.create!(user: sw_user, first_name: 'Bob', last_name: 'Brown',
-                          email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney')
+                          email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney', status: 'approved')
+  end
+  let(:pending_sw_user) { User.create!(email: 'pending@test.com', password: 'password123', first_name: 'Pat', last_name: 'Pending') }
+  let(:pending_worker) do
+    SupportWorker.create!(user: pending_sw_user, first_name: 'Pat', last_name: 'Pending',
+                          email: 'pending@test.com', phone: '0411111111', age: 25, location: 'Melbourne', status: 'pending')
   end
 
   let(:messages_params) { { messages: [{ role: 'user', content: 'I need help with bathing' }] } }
@@ -34,16 +39,31 @@ RSpec.describe "AiBookingController", type: :request do
       end
     end
 
-    context 'when a support worker (not a client) is logged in' do
+    context 'when a pending support worker is logged in' do
       before do
-        support_worker
-        post api_login_path, params: { email: sw_user.email, password: 'password123' }
+        pending_worker
+        post api_login_path, params: { email: pending_sw_user.email, password: 'password123' }
       end
 
       it 'returns forbidden' do
         post '/api/ai_booking/chat', params: messages_params
         expect(response).to have_http_status(:forbidden)
       end
+    end
+
+    context 'when an approved support worker is logged in' do
+      before do
+        support_worker
+        post api_login_path, params: { email: sw_user.email, password: 'password123' }
+      end
+
+      it 'returns the text reply from Claude' do
+        allow_any_instance_of(Anthropic::Client).to receive(:messages).and_return(text_response)
+        post '/api/ai_booking/chat', params: messages_params
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['message']).to eq('I found some workers for you.')
+      end
+
     end
 
     context 'when a client is logged in' do

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe "AppointmentsController", type: :request do
     let(:client_user) { User.create!(email: 'client@test.com', first_name: 'Jane', last_name: 'Doe', password: 'password123') }
     let(:client) { Client.create!(user_id: client_user.id, first_name: client_user.first_name, last_name: client_user.last_name) }
     let(:support_worker_user) { User.create!(email: 'test2@test.com', password: 'password123', first_name: 'Bob', last_name: 'Brown', role: 'support_worker') }
-    let(:support_worker) { SupportWorker.create!(email: support_worker_user.email, phone: '6773 2092', age: 35, location: 'Sydney', user_id: support_worker_user.id, first_name: support_worker_user.first_name, last_name: support_worker_user.last_name) }
+    let(:support_worker) { SupportWorker.create!(email: support_worker_user.email, phone: '6773 2092', age: 35, location: 'Sydney', user_id: support_worker_user.id, first_name: support_worker_user.first_name, last_name: support_worker_user.last_name, status: 'approved') }
+    let(:pending_sw_user) { User.create!(email: 'pending@test.com', password: 'password123', first_name: 'Pat', last_name: 'Pending') }
+    let(:pending_worker) { SupportWorker.create!(email: 'pending@test.com', phone: '0411111111', age: 28, location: 'Melbourne', user_id: pending_sw_user.id, first_name: 'Pat', last_name: 'Pending', status: 'pending') }
     let(:appointment_params) { { appointment: { date: "2026-05-01", duration: 30, location: "location", notes: "some notes", client_id: client.id, support_worker_id: support_worker.id } } }
     let(:invalid_appointment_params) { { appointment: { duration: 30, location: "location", notes: "some notes", client_id: client.id, support_worker_id: support_worker.id, date: nil } } }
     let(:invalid_user) { User.create!(email: 'invalid@test.com', first_name: 'Invalid', last_name: 'User', password: 'password123') }
@@ -153,8 +155,24 @@ RSpec.describe "AppointmentsController", type: :request do
       context 'when an appointment is deleted' do
         it 'soft deletes it, leaπving a datetime value on the deleted_at column on the record' do
           delete api_appointment_path(appointment)
-          expect(appointment.reload.deleted_at).not_to be nil 
+          expect(appointment.reload.deleted_at).not_to be nil
         end
+      end
+    end
+
+    describe "pending support worker restrictions" do
+      before { pending_worker; post api_login_path, params: { email: pending_sw_user.email, password: 'password123' } }
+
+      it 'returns an empty list for GET /api/appointments' do
+        get api_appointments_path
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to be_empty
+      end
+
+      it 'returns forbidden for POST /api/appointments' do
+        post api_appointments_path, params: appointment_params
+        expect(response).to have_http_status(:forbidden)
+        expect(Appointment.count).to eq(0)
       end
     end
 end

--- a/spec/controllers/clients_controller_spec.rb
+++ b/spec/controllers/clients_controller_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe "ClientsController", type: :request do
   let(:other_user) { User.create!(email: 'other@test.com', password: 'password123', first_name: 'Alice', last_name: 'Smith') }
   let(:other_client) { Client.create!(user: other_user, first_name: 'Alice', last_name: 'Smith') }
   let(:sw_user) { User.create!(email: 'sw@test.com', password: 'password123', first_name: 'Bob', last_name: 'Brown') }
-  let(:support_worker) { SupportWorker.create!(user: sw_user, first_name: 'Bob', last_name: 'Brown', email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney') }
+  let(:support_worker) { SupportWorker.create!(user: sw_user, first_name: 'Bob', last_name: 'Brown', email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney', status: 'approved') }
+
+  let(:pending_sw_user) { User.create!(email: 'pending@test.com', password: 'password123', first_name: 'Pat', last_name: 'Pending') }
+  let(:pending_worker) { SupportWorker.create!(user: pending_sw_user, first_name: 'Pat', last_name: 'Pending', email: 'pending@test.com', phone: '0411111111', age: 25, location: 'Melbourne', status: 'pending') }
 
   describe "GET /api/clients" do
     context 'when unauthenticated' do
@@ -25,13 +28,22 @@ RSpec.describe "ClientsController", type: :request do
       end
     end
 
-    context 'when logged in as a support worker' do
+    context 'when logged in as an approved support worker' do
       before { client; support_worker; post api_login_path, params: { email: sw_user.email, password: 'password123' } }
 
       it 'returns all clients' do
         get api_clients_path
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body).count).to eq(1)
+      end
+    end
+
+    context 'when logged in as a pending support worker' do
+      before { pending_worker; post api_login_path, params: { email: pending_sw_user.email, password: 'password123' } }
+
+      it 'returns forbidden' do
+        get api_clients_path
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
@@ -60,13 +72,22 @@ RSpec.describe "ClientsController", type: :request do
       end
     end
 
-    context 'when logged in as a support worker' do
+    context 'when logged in as an approved support worker' do
       before { client; support_worker; post api_login_path, params: { email: sw_user.email, password: 'password123' } }
 
       it 'returns any client record' do
         get api_client_path(client)
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['id']).to eq(client.id)
+      end
+    end
+
+    context 'when logged in as a pending support worker' do
+      before { client; pending_worker; post api_login_path, params: { email: pending_sw_user.email, password: 'password123' } }
+
+      it 'returns forbidden' do
+        get api_client_path(client)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/controllers/support_workers_controller_spec.rb
+++ b/spec/controllers/support_workers_controller_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe "SupportWorkersController", type: :request do
       age: 30,
       location: 'Sydney',
       bio: 'Experienced carer',
-      experience: '5 years in disability support'
+      experience: '5 years in disability support',
+      status: 'approved'
     )
   end
 

--- a/spec/controllers/vetting_controller_spec.rb
+++ b/spec/controllers/vetting_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe "VettingController", type: :request do
+  let(:sw_user) { User.create!(email: 'sw@test.com', password: 'password123', first_name: 'Alex', last_name: 'Smith') }
+  let(:support_worker) do
+    SupportWorker.create!(user: sw_user, first_name: 'Alex', last_name: 'Smith',
+                          email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney', status: 'pending')
+  end
+  let(:plain_user) { User.create!(email: 'plain@test.com', password: 'password123', first_name: 'Jan', last_name: 'Doe') }
+
+  let(:chat_params) { { message: 'My police check number is ABC123456', history: [] } }
+
+  let(:text_reply) do
+    { 'content' => [{ 'type' => 'text', 'text' => 'Thank you! Now please provide your WWCC number.' }] }
+  end
+
+  let(:complete_reply) do
+    { 'content' => [{ 'type' => 'text', 'text' => "Great, all done! [VETTING_COMPLETE]" }] }
+  end
+
+  let(:extracted_data) do
+    { 'content' => [{ 'type' => 'text', 'text' => '{"police_check_number":"ABC123456","wwcc_number":"WWC7654321","recommendation":"approved","notes":"All checks passed"}' }] }
+  end
+
+  describe "POST /api/vetting/chat" do
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        post '/api/vetting/chat', params: chat_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when logged in as a user without a support worker profile' do
+      before { plain_user; post api_login_path, params: { email: plain_user.email, password: 'password123' } }
+
+      it 'returns forbidden' do
+        post '/api/vetting/chat', params: chat_params
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when logged in as a support worker' do
+      before { support_worker; post api_login_path, params: { email: sw_user.email, password: 'password123' } }
+
+      it 'returns the assistant reply' do
+        anthropic_client = double
+        allow(Anthropic::Client).to receive(:new).and_return(anthropic_client)
+        allow(anthropic_client).to receive(:messages).and_return(text_reply)
+        post '/api/vetting/chat', params: chat_params
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['reply']).to eq('Thank you! Now please provide your WWCC number.')
+        expect(body['complete']).to be_falsey
+      end
+
+      it 'marks complete and updates the worker when VETTING_COMPLETE is present' do
+        anthropic_client = double
+        allow(Anthropic::Client).to receive(:new).and_return(anthropic_client)
+        allow(anthropic_client).to receive(:messages).and_return(complete_reply, extracted_data)
+        post '/api/vetting/chat', params: {
+          message: 'My WWCC is WWC7654321',
+          history: [{ role: 'user', content: 'ABC123456' }, { role: 'assistant', content: 'Thank you!' }]
+        }
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['complete']).to be true
+        expect(body['recommendation']).to eq('approved')
+        expect(body['reply']).not_to include('[VETTING_COMPLETE]')
+        support_worker.reload
+        expect(support_worker.police_check_number).to eq('ABC123456')
+        expect(support_worker.wwcc_number).to eq('WWC7654321')
+        expect(support_worker.agent_recommendation).to eq('approved')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Pending support workers are blocked from `/api/clients`, `/api/appointments` (create), and `/api/ai_booking/chat`
- Vetting agent now rejects reference numbers shorter than 6 chars or missing digits (fixes acceptance of values like "bom" or "prim")
- All existing specs updated to use `status: 'approved'` on support worker fixtures; new VettingController spec added

## Test plan
- [ ] Pending worker receives 403 on `GET /api/clients`
- [ ] Pending worker receives 403 on `POST /api/appointments`
- [ ] Pending worker receives 403 on `POST /api/ai_booking/chat`
- [ ] Approved worker can access all above endpoints
- [ ] Vetting agent rejects short/digit-free strings and asks worker to re-enter
- [ ] All 48 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)