### PR TITLE
Add stats, workers list, and specs to admin dashboard

### DIFF
--- a/app/controllers/api/admin_controller.rb
+++ b/app/controllers/api/admin_controller.rb
@@ -21,8 +21,24 @@ module Api
     end
 
     def appointments
-      appts = Appointment.includes(:client, :support_worker).order(date: :asc)
+      appts = Appointment.active.includes(:client, :support_worker).order(date: :asc)
       render json: appts.as_json(include: [:client, :support_worker])
+    end
+
+    def workers
+      workers = SupportWorker.where(status: 'approved').includes(:user, :specializations)
+      render json: workers.as_json(include: { specializations: {}, user: { only: [:email] } })
+    end
+
+    def stats
+      render json: {
+        approved_workers: SupportWorker.where(status: 'approved').count,
+        pending_workers:  SupportWorker.pending_approval.count,
+        total_clients:    Client.count,
+        appointments_this_week: Appointment.active
+          .where(date: Time.current.beginning_of_week..Time.current.end_of_week)
+          .count,
+      }
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
       patch 'applications/:id/approve', to: '/api/admin#approve', as: :approve_application
       patch 'applications/:id/reject', to: '/api/admin#reject', as: :reject_application
       get 'appointments', to: '/api/admin#appointments'
+      get 'workers', to: '/api/admin#workers'
+      get 'stats', to: '/api/admin#stats'
     end
   end
 end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe "AdminController", type: :request do
+  let(:admin_user) { User.create!(email: 'admin@test.com', password: 'password123', first_name: 'Admin', last_name: 'User', is_admin: true) }
+  let(:plain_user)  { User.create!(email: 'plain@test.com', password: 'password123', first_name: 'Jan', last_name: 'Doe') }
+
+  let(:sw_user) { User.create!(email: 'sw@test.com', password: 'password123', first_name: 'Bob', last_name: 'Brown') }
+  let(:approved_worker) do
+    SupportWorker.create!(user: sw_user, first_name: 'Bob', last_name: 'Brown',
+                          email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney', status: 'approved')
+  end
+
+  let(:pending_sw_user) { User.create!(email: 'pending@test.com', password: 'password123', first_name: 'Pat', last_name: 'Pending') }
+  let(:pending_worker) do
+    SupportWorker.create!(user: pending_sw_user, first_name: 'Pat', last_name: 'Pending',
+                          email: 'pending@test.com', phone: '0411111111', age: 25, location: 'Melbourne', status: 'pending')
+  end
+
+  let(:client_user) { User.create!(email: 'client@test.com', password: 'password123', first_name: 'Jane', last_name: 'Smith') }
+  let(:client) { Client.create!(user: client_user, first_name: 'Jane', last_name: 'Smith') }
+
+  def login_as(user)
+    post api_login_path, params: { email: user.email, password: 'password123' }
+  end
+
+  describe "GET /api/admin/stats" do
+    context 'when not an admin' do
+      before { plain_user; login_as(plain_user) }
+
+      it 'returns forbidden' do
+        get '/api/admin/stats'
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when logged in as admin' do
+      before do
+        approved_worker; pending_worker; client
+        login_as(admin_user)
+      end
+
+      it 'returns correct counts' do
+        get '/api/admin/stats'
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['approved_workers']).to eq(1)
+        expect(body['pending_workers']).to eq(1)
+        expect(body['total_clients']).to eq(1)
+        expect(body).to have_key('appointments_this_week')
+      end
+    end
+  end
+
+  describe "GET /api/admin/workers" do
+    context 'when not an admin' do
+      before { plain_user; login_as(plain_user) }
+
+      it 'returns forbidden' do
+        get '/api/admin/workers'
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when logged in as admin' do
+      before { approved_worker; pending_worker; login_as(admin_user) }
+
+      it 'returns only approved workers' do
+        get '/api/admin/workers'
+        expect(response).to have_http_status(:ok)
+        names = JSON.parse(response.body).map { |w| w['first_name'] }
+        expect(names).to include('Bob')
+        expect(names).not_to include('Pat')
+      end
+    end
+  end
+
+  describe "GET /api/admin/applications" do
+    context 'when logged in as admin' do
+      before { approved_worker; pending_worker; login_as(admin_user) }
+
+      it 'returns only pending applications' do
+        get '/api/admin/applications'
+        expect(response).to have_http_status(:ok)
+        names = JSON.parse(response.body).map { |w| w['first_name'] }
+        expect(names).to include('Pat')
+        expect(names).not_to include('Bob')
+      end
+    end
+  end
+
+  describe "PATCH /api/admin/applications/:id/approve" do
+    before { pending_worker; login_as(admin_user) }
+
+    it 'sets the worker status to approved' do
+      patch "/api/admin/applications/#{pending_worker.id}/approve"
+      expect(response).to have_http_status(:ok)
+      expect(pending_worker.reload.status).to eq('approved')
+    end
+  end
+
+  describe "PATCH /api/admin/applications/:id/reject" do
+    before { pending_worker; login_as(admin_user) }
+
+    it 'sets the worker status to rejected' do
+      patch "/api/admin/applications/#{pending_worker.id}/reject"
+      expect(response).to have_http_status(:ok)
+      expect(pending_worker.reload.status).to eq('rejected')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `GET /api/admin/stats` — approved workers, pending workers, total clients, appointments this week
- `GET /api/admin/workers` — approved workers only for the roster tab
- Appointments scoped to active (soft-deleted excluded)
- AdminController spec covering all endpoints (7 examples)

## Test plan
- [ ] Stats endpoint returns correct counts
- [ ] Workers endpoint returns only approved workers
- [ ] All 7 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)