### PR TITLE
Scope approved workers to the approving admin

### DIFF
--- a/app/controllers/api/admin_controller.rb
+++ b/app/controllers/api/admin_controller.rb
@@ -10,7 +10,7 @@ module Api
 
     def approve
       worker = SupportWorker.find(params[:id])
-      worker.update!(status: 'approved')
+      worker.update!(status: 'approved', approved_by_id: current_user.id)
       render json: { message: 'Support worker approved' }
     end
 
@@ -26,13 +26,13 @@ module Api
     end
 
     def workers
-      workers = SupportWorker.where(status: 'approved').includes(:user, :specializations)
+      workers = SupportWorker.where(status: 'approved', approved_by_id: current_user.id).includes(:user, :specializations)
       render json: workers.as_json(include: { specializations: {}, user: { only: [:email] } })
     end
 
     def stats
       render json: {
-        approved_workers: SupportWorker.where(status: 'approved').count,
+        approved_workers: SupportWorker.where(status: 'approved', approved_by_id: current_user.id).count,
         pending_workers:  SupportWorker.pending_approval.count,
         total_clients:    Client.count,
         appointments_this_week: Appointment.active

--- a/db/migrate/20260507122835_add_approved_by_to_support_workers.rb
+++ b/db/migrate/20260507122835_add_approved_by_to_support_workers.rb
@@ -1,0 +1,5 @@
+class AddApprovedByToSupportWorkers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :support_workers, :approved_by_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_07_100000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_07_122835) do
   create_table "appointments", force: :cascade do |t|
     t.datetime "date"
     t.integer "duration"
@@ -99,6 +99,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_07_100000) do
     t.string "wwcc_number"
     t.text "check_notes"
     t.string "agent_recommendation"
+    t.integer "approved_by_id"
     t.index ["user_id"], name: "index_support_workers_on_user_id"
   end
 

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -4,10 +4,20 @@ RSpec.describe "AdminController", type: :request do
   let(:admin_user) { User.create!(email: 'admin@test.com', password: 'password123', first_name: 'Admin', last_name: 'User', is_admin: true) }
   let(:plain_user)  { User.create!(email: 'plain@test.com', password: 'password123', first_name: 'Jan', last_name: 'Doe') }
 
+  let(:other_admin_user) { User.create!(email: 'admin2@test.com', password: 'password123', first_name: 'Other', last_name: 'Admin', is_admin: true) }
+
   let(:sw_user) { User.create!(email: 'sw@test.com', password: 'password123', first_name: 'Bob', last_name: 'Brown') }
   let(:approved_worker) do
     SupportWorker.create!(user: sw_user, first_name: 'Bob', last_name: 'Brown',
-                          email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney', status: 'approved')
+                          email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney',
+                          status: 'approved', approved_by_id: admin_user.id)
+  end
+
+  let(:other_sw_user) { User.create!(email: 'other_sw@test.com', password: 'password123', first_name: 'Sara', last_name: 'Green') }
+  let(:other_approved_worker) do
+    SupportWorker.create!(user: other_sw_user, first_name: 'Sara', last_name: 'Green',
+                          email: 'other_sw@test.com', phone: '0422222222', age: 28, location: 'Brisbane',
+                          status: 'approved', approved_by_id: other_admin_user.id)
   end
 
   let(:pending_sw_user) { User.create!(email: 'pending@test.com', password: 'password123', first_name: 'Pat', last_name: 'Pending') }
@@ -35,11 +45,11 @@ RSpec.describe "AdminController", type: :request do
 
     context 'when logged in as admin' do
       before do
-        approved_worker; pending_worker; client
+        approved_worker; other_approved_worker; pending_worker; client
         login_as(admin_user)
       end
 
-      it 'returns correct counts' do
+      it 'counts only workers this admin approved' do
         get '/api/admin/stats'
         expect(response).to have_http_status(:ok)
         body = JSON.parse(response.body)
@@ -62,13 +72,14 @@ RSpec.describe "AdminController", type: :request do
     end
 
     context 'when logged in as admin' do
-      before { approved_worker; pending_worker; login_as(admin_user) }
+      before { approved_worker; other_approved_worker; pending_worker; login_as(admin_user) }
 
-      it 'returns only approved workers' do
+      it 'returns only workers this admin approved' do
         get '/api/admin/workers'
         expect(response).to have_http_status(:ok)
         names = JSON.parse(response.body).map { |w| w['first_name'] }
         expect(names).to include('Bob')
+        expect(names).not_to include('Sara')
         expect(names).not_to include('Pat')
       end
     end
@@ -91,10 +102,11 @@ RSpec.describe "AdminController", type: :request do
   describe "PATCH /api/admin/applications/:id/approve" do
     before { pending_worker; login_as(admin_user) }
 
-    it 'sets the worker status to approved' do
+    it 'sets the worker status to approved and records the approving admin' do
       patch "/api/admin/applications/#{pending_worker.id}/approve"
       expect(response).to have_http_status(:ok)
       expect(pending_worker.reload.status).to eq('approved')
+      expect(pending_worker.reload.approved_by_id).to eq(admin_user.id)
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds `approved_by_id` column to `support_workers`
- Records which admin approved each worker on the approve action
- `/admin/workers` and the `approved_workers` stat now only return workers this admin approved

## Test plan
- [ ] Two-admin scenario: each admin only sees their own approved workers
- [ ] All 7 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)