### PR TITLE
Add visit reports with AI draft generation

### DIFF
--- a/app/controllers/api/visit_reports_controller.rb
+++ b/app/controllers/api/visit_reports_controller.rb
@@ -1,0 +1,75 @@
+module Api
+  class VisitReportsController < ApplicationController
+    before_action :require_support_worker
+
+    def index
+      worker = current_user.support_worker
+      reports = VisitReport.where(user_id: current_user.id)
+                           .includes(:appointment)
+                           .order(created_at: :desc)
+      render json: reports.as_json(include: :appointment)
+    end
+
+    def show
+      report = VisitReport.find_by(appointment_id: params[:id])
+      render json: report
+    end
+
+    def create
+      report = VisitReport.find_or_initialize_by(appointment_id: params[:appointment_id])
+      report.assign_attributes(
+        user_id: current_user.id,
+        client_id: params[:client_id],
+        date: params[:date] || Date.today,
+        activities: params[:activities],
+        observations: params[:observations],
+        follow_up_actions: params[:follow_up_actions]
+      )
+      if report.save
+        render json: report, status: :ok
+      else
+        render json: { errors: report.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    def draft
+      appointment = Appointment.includes(:client, :support_worker).find(params[:appointment_id])
+      client = appointment.client
+      worker = appointment.support_worker
+
+      anthropic = Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY'])
+      response = anthropic.messages(parameters: {
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 512,
+        system: 'You are a disability support worker writing a brief post-session visit report. Be professional and concise. Respond ONLY with valid JSON matching this schema exactly: {"activities": "...", "observations": "...", "follow_up_actions": "..."}. No markdown, no extra keys.',
+        messages: [{
+          role: 'user',
+          content: <<~PROMPT
+            Write a visit report for this session:
+            - Client: #{client.first_name} #{client.last_name}
+            - Health conditions: #{client.health_conditions.presence || 'none recorded'}
+            - Support worker: #{worker.first_name} #{worker.last_name}
+            - Date: #{appointment.date.strftime('%A %-d %B %Y')}
+            - Duration: #{appointment.duration} minutes
+            - Location: #{appointment.location}
+            - Notes: #{appointment.notes.presence || 'none'}
+          PROMPT
+        }]
+      })
+
+      text = response['content'].find { |b| b['type'] == 'text' }&.fetch('text', '{}')
+      draft = JSON.parse(text)
+      render json: draft
+    rescue JSON::ParserError
+      render json: { activities: '', observations: '', follow_up_actions: '' }
+    end
+
+    private
+
+    def require_support_worker
+      unless current_user&.support_worker&.status == 'approved'
+        render json: { error: 'Forbidden' }, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/models/visit_report.rb
+++ b/app/models/visit_report.rb
@@ -1,2 +1,6 @@
 class VisitReport < ApplicationRecord
+  belongs_to :appointment
+  belongs_to :support_worker, foreign_key: :user_id, primary_key: :user_id, optional: true
+
+  validates :appointment_id, uniqueness: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,8 @@ Rails.application.routes.draw do
         get :suggest_booking
       end
     end
-    resources :visit_reports
+    post 'visit_reports/draft', to: 'visit_reports#draft'
+    resources :visit_reports, only: [:index, :show, :create]
     post 'ai_booking/chat', to: 'ai_booking#chat'
     post 'chat_simulation', to: 'chat_simulation#simulate'
     get 'dashboard', to: 'dashboard#show'

--- a/spec/controllers/visit_reports_controller_spec.rb
+++ b/spec/controllers/visit_reports_controller_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe 'VisitReportsController', type: :request do
+  let(:sw_user) { User.create!(email: 'sw@test.com', password: 'password123', first_name: 'Alice', last_name: 'Smith', role: 'support_worker') }
+  let(:support_worker) { SupportWorker.create!(user: sw_user, first_name: 'Alice', last_name: 'Smith', email: 'sw@test.com', phone: '0400000000', age: 30, location: 'Sydney', status: 'approved') }
+  let(:client_user) { User.create!(email: 'client@test.com', password: 'password123', first_name: 'Jane', last_name: 'Doe') }
+  let(:client) { Client.create!(user: client_user, first_name: 'Jane', last_name: 'Doe') }
+  let(:appointment) { Appointment.create!(client: client, support_worker: support_worker, date: 1.day.ago) }
+
+  let(:other_sw_user) { User.create!(email: 'other_sw@test.com', password: 'password123', first_name: 'Bob', last_name: 'Jones', role: 'support_worker') }
+  let(:other_sw) { SupportWorker.create!(user: other_sw_user, first_name: 'Bob', last_name: 'Jones', email: 'other_sw@test.com', phone: '0411111111', age: 28, location: 'Melbourne', status: 'pending') }
+
+  def login_as(user)
+    post api_login_path, params: { email: user.email, password: 'password123' }
+  end
+
+  describe 'POST /api/visit_reports' do
+    context 'as an approved support worker' do
+      before do
+        support_worker
+        login_as(sw_user)
+      end
+
+      it 'creates a visit report and returns 200' do
+        post api_visit_reports_path, params: {
+          appointment_id: appointment.id,
+          client_id: client.id,
+          date: appointment.date,
+          activities: 'Helped with cooking',
+          observations: 'Client was engaged',
+          follow_up_actions: 'Book next session'
+        }
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['activities']).to eq('Helped with cooking')
+        expect(body['observations']).to eq('Client was engaged')
+      end
+
+      it 'upserts: updating an existing report for the same appointment' do
+        VisitReport.create!(user_id: sw_user.id, client_id: client.id, appointment_id: appointment.id,
+                            date: appointment.date, activities: 'Old activity')
+        post api_visit_reports_path, params: {
+          appointment_id: appointment.id,
+          client_id: client.id,
+          date: appointment.date,
+          activities: 'Updated activity'
+        }
+        expect(response).to have_http_status(:ok)
+        expect(VisitReport.where(appointment_id: appointment.id).count).to eq(1)
+        expect(VisitReport.find_by(appointment_id: appointment.id).activities).to eq('Updated activity')
+      end
+    end
+
+    context 'as a pending (not approved) support worker' do
+      before do
+        other_sw
+        login_as(other_sw_user)
+      end
+
+      it 'returns 403 forbidden' do
+        post api_visit_reports_path, params: { appointment_id: appointment.id, client_id: client.id }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when not logged in' do
+      it 'returns 403 forbidden' do
+        post api_visit_reports_path, params: { appointment_id: appointment.id }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'GET /api/visit_reports' do
+    before do
+      support_worker
+      VisitReport.create!(user_id: sw_user.id, client_id: client.id, appointment_id: appointment.id,
+                          date: appointment.date, activities: 'Cooking assistance')
+      login_as(sw_user)
+    end
+
+    it 'returns the worker\'s visit reports' do
+      get api_visit_reports_path
+      body = JSON.parse(response.body)
+      expect(body.length).to eq(1)
+      expect(body.first['activities']).to eq('Cooking assistance')
+    end
+  end
+
+  describe 'POST /api/visit_reports/draft' do
+    before do
+      support_worker
+      login_as(sw_user)
+    end
+
+    it 'returns a draft with activities, observations, and follow_up_actions' do
+      draft_response = {
+        'content' => [{ 'type' => 'text', 'text' => '{"activities":"Helped with cooking","observations":"Client was well","follow_up_actions":"Follow up next week"}' }]
+      }
+      fake_client = instance_double(Anthropic::Client, messages: draft_response)
+      allow(Anthropic::Client).to receive(:new).and_return(fake_client)
+
+      post '/api/visit_reports/draft', params: { appointment_id: appointment.id }
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body).to include('activities', 'observations', 'follow_up_actions')
+      expect(body['activities']).to eq('Helped with cooking')
+    end
+
+    it 'returns empty fields when AI response is not valid JSON' do
+      bad_response = { 'content' => [{ 'type' => 'text', 'text' => 'not json' }] }
+      fake_client = instance_double(Anthropic::Client, messages: bad_response)
+      allow(Anthropic::Client).to receive(:new).and_return(fake_client)
+
+      post '/api/visit_reports/draft', params: { appointment_id: appointment.id }
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body['activities']).to eq('')
+      expect(body['observations']).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `VisitReport` model with `belongs_to :appointment` and uniqueness constraint per appointment
- `VisitReportsController` with `index`, `show`, `create`, and `draft` actions
- `POST /visit_reports/draft` uses Claude Haiku to generate a visit report from appointment context
- Access restricted to approved support workers via `require_support_worker` before action
- Draft route placed before `resources :visit_reports` to avoid routing conflict with `show`

## Test plan
- [ ] `bundle exec rspec spec/controllers/visit_reports_controller_spec.rb` — 7 examples, 0 failures
- [ ] Approved worker can POST `/visit_reports` and get a saved report back
- [ ] Upsert: POSTing again for the same appointment updates rather than creates a second record
- [ ] Pending/unauthenticated users get 403
- [ ] Draft endpoint returns `activities`, `observations`, `follow_up_actions` populated by AI
- [ ] Draft endpoint returns empty fields gracefully when AI response is not valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)